### PR TITLE
Set new event name to ready for Turbolinks 5

### DIFF
--- a/app/assets/javascripts/capybara_turbolinks.coffee.erb
+++ b/app/assets/javascripts/capybara_turbolinks.coffee.erb
@@ -1,7 +1,7 @@
 <% if Rails.env.test? %>
-$(document).on 'page:fetch', ->
+$(document).on 'page:fetch, turbolinks:request-start', ->
   $('body').removeClass('page--complete').addClass('page--fetch')
 
-$(document).on 'page:partial-load, page:load', ->
+$(document).on 'page:partial-load, page:load, turbolinks:load', ->
   $('body').removeClass('page--fetch').addClass('page--complete')
 <% end %>


### PR DESCRIPTION
In Turbolinks 5, these events are obsolete. We should use new event name.
https://github.com/turbolinks/turbolinks/blob/80399be2312f6b9b2ee926651068371ad57fd567/README.md